### PR TITLE
improve undefined behavior case in bzhi emulation

### DIFF
--- a/zp7.c
+++ b/zp7.c
@@ -214,7 +214,7 @@ uint64_t zp7_pdep_pre_64(uint64_t a, const zp7_masks_64_t *masks) {
     // If we don't have BZHI, use a portable workaround.  Since (mask == -1)
     // is equivalent to popcnt(mask) >> 6, use that to mask out the 1 << 64
     // case.
-    uint64_t pop_mask = (1ULL << popcnt) & ~(popcnt >> 6);
+    uint64_t pop_mask = (1ULL << popcnt) & ((popcnt >> 6) - 1);
     a &= pop_mask - 1;
 #endif
 


### PR DESCRIPTION
Doing `~(popcnt >> 6)` gives us -2 when popcnt is 64, otherwise it gives us -1. ANDing this value with `1 << popcnt` is fine when `1 << 64` gives us `1`, which it may on a lot of machines, but C does not guarantee that to be the case. Instead, we could do `(popcnt >> 6) - 1` which gives us 0 when the popcnt is 64, and `(0 & undefined)` is (hopefully?) 0. When the popcnt is not 64, we get `-1` from the revised expression, and ANDing with that works properly too.

Please test before merging!