### PR TITLE
Use another implementation for PDEP

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,9 @@ any architecture.
 [CLMUL instruction set](https://en.wikipedia.org/wiki/CLMUL_instruction_set), which
 is on most x86 CPUs since ~2010.  Using CLMUL gives a fairly significant
 speedup and code size reduction.
-* `HAS_BZHI`: whether the processor has BZHI, which was introduced in the same [BMI2
-instructions](https://en.wikipedia.org/wiki/Bit_Manipulation_Instruction_Sets) as
-PEXT/PDEP. This is only used once for PDEP, so it matters much less than CLMUL.
-* `HAS_POPCNT`: whether the processor has POPCNT, which was introduced in
-[SSE4a/SSE4.2](https://en.wikipedia.org/wiki/SSE4). Like BZHI, this is only used
-once for PDEP, but matters more for speed, as the software POPCNT is several instructions.
 
 This code is hardcoded to operate on 64 bits. It could easily be adapted
 for 32 bits by changing `N_BITS` to 5, replacing `uint64_t` with `uint32_t`,
 and modifying the popcount/bzhi intrinsics/polyfills. This will be slightly
 faster and will save some memory for pre-calculated masks, but is left out
 for simplicity. Smaller inputs could likewise be supported by similar modifications.
-
-There are also a couple optimizations that could be made for precomputed
-masks for PDEP: the POPCNT/BZHI combination, as well as six shifts, depend only
-on the mask, and could be precomputed. I've left this out for now in the interest
-of simplicity and allowing precomputed masks to be shared between PEXT and PDEP.

--- a/test.c
+++ b/test.c
@@ -26,8 +26,6 @@
 #include <immintrin.h>
 
 #define HAS_CLMUL
-#define HAS_BZHI
-#define HAS_POPCNT
 
 #include "zp7.c"
 


### PR DESCRIPTION
This approach is from chapter 7 of Hacker's Delight. It eliminates the need of POPCNT and BZHI instructions totally, enhancing portability.

GCC generates less instructions compared to the original implementation.
