### PR TITLE
Optimize carry bit computation for parallel prefix XOR

### DIFF
--- a/zp7.c
+++ b/zp7.c
@@ -56,15 +56,13 @@
 // of the 64 counts, another holds bit 1, etc. We can compute these counts
 // fairly easily using a parallel prefix XOR (XOR is equivalent to a 1-bit
 // adder that wraps around and ignores carrying). Using parallel prefix XOR as
-// a 1-bit adder, we can build an n-bit adder by shifting the result left by
-// one and ANDing with the input bits: this computes the carry by seeing where
-// an input bit causes the 1-bit sum to overflow from 1 to 0. The shift left
-// is needed anyways, because we want the PPP values to represent population
-// counts *below* each bit, not including the bit itself.
+// a 1-bit adder, we can build an n-bit adder by clearing the input bits that
+// are set in the result: this computes the carry by seeing where an input bit
+// causes the 1-bit sum to overflow from 1 to 0.
 //
 // For processors with the CLMUL instructions (most x86 CPUs since ~2010), we
-// can do the parallel prefix XOR and left shift in one instruction, by
-// doing a carry-less multiply by -2. This is enabled with the HAS_CLMUL define.
+// can do the parallel prefix XOR in one instruction, by doing a carry-less
+// multiply by -1. This is enabled with the HAS_CLMUL define.
 //
 // Anyways, once we have these six 64-bit values of the PPP, we can use each
 // PPP bit to shift input bits by a power of two. That is, input bits that are
@@ -124,44 +122,44 @@ zp7_masks_64_t zp7_ppp_64(uint64_t mask) {
     zp7_masks_64_t r;
     r.mask = mask;
 
-    // Count *unset* bits
-    mask = ~mask;
+    // Count *unset* bits *below* each bit.
+    mask = ~mask << 1;
 
 #ifdef HAS_CLMUL
     // Move the mask and -2 to XMM registers for CLMUL
     __m128i m = _mm_cvtsi64_si128(mask);
-    __m128i neg_2 = _mm_cvtsi64_si128(-2LL);
+    __m128i neg_1 = _mm_cvtsi64_si128(-1LL);
     for (int i = 0; i < N_BITS - 1; i++) {
-        // Do a 1-bit parallel prefix popcount, shifted left by 1,
-        // in one carry-less multiply by -2.
-        __m128i bit = _mm_clmulepi64_si128(m, neg_2, 0);
+        // Do a 1-bit parallel prefix popcount, in one carry-less multiply by
+        // -1.
+        __m128i bit = _mm_clmulepi64_si128(m, neg_1, 0);
         r.ppp_bit[i] = _mm_cvtsi128_si64(bit);
 
         // Get the carry bit of the 1-bit parallel prefix popcount. On
         // the next iteration, we will sum this bit to get the next mask
-        m = _mm_and_si128(m, bit);
+        m = _mm_andnot_si128(bit, m);
     }
-    // For the last iteration, we can use a regular multiply by -2 instead of a
+    // For the last iteration, we can use a regular multiply by -1 instead of a
     // carry-less one (or rather, a strength reduction of that, with
     // neg/add/etc), since there can't be any carries anyways. That is because
     // the last value of m (which has one bit set for every 32nd unset mask bit)
     // has at most two bits set in it, when mask is zero and thus there are 64
     // bits set in ~mask. If two bits are set, one of them is the top bit, which
     // gets shifted out, since we're counting bits below each mask bit.
-    r.ppp_bit[N_BITS - 1] = -_mm_cvtsi128_si64(m) << 1;
+    r.ppp_bit[N_BITS - 1] = -_mm_cvtsi128_si64(m);
 #else
     for (int i = 0; i < N_BITS - 1; i++) {
-        // Do a 1-bit parallel prefix popcount, shifted left by 1
-        uint64_t bit = prefix_sum(mask << 1);
+        // Do a 1-bit parallel prefix popcount
+        uint64_t bit = prefix_sum(mask);
         r.ppp_bit[i] = bit;
 
         // Get the carry bit of the 1-bit parallel prefix popcount. On
         // the next iteration, we will sum this bit to get the next mask
-        mask &= bit;
+        mask &= ~bit;
     }
     // The last iteration won't carry, so just use neg/shift. See the CLMUL
     // case above for justification.
-    r.ppp_bit[N_BITS - 1] = -mask << 1;
+    r.ppp_bit[N_BITS - 1] = -mask;
 #endif
 
     return r;


### PR DESCRIPTION
Updated the formula for computing carry bits from
`(input & (result << 1))` to `(input & ~result)`.

This new approach utilizes the ANDN instruction, reducing the computation to a single instruction.